### PR TITLE
Add layout with sidebar and progress bar

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,9 +9,6 @@
         margin: 0;
         padding: 0;
         height: 100%;
-        display: flex;
-        justify-content: center;
-        align-items: center;
         background-color: #f0f0f0;
       }
       #root {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,12 +18,22 @@ export default function App() {
   };
 
   return (
-    <div className="container" onClick={handleClick}>
-      {isAnimating ? (
-        <video src={clickAnimation} autoPlay onEnded={handleEnded} />
-      ) : (
-        <video src={defaultVideo} autoPlay loop />
-      )}
+    <div className="layout">
+      <div className="progress-bar">
+        <div className="progress" />
+      </div>
+      <div className="content">
+        <div className="sidebar">Sidebar</div>
+        <div className="main">
+          <div className="avatar-container" onClick={handleClick}>
+            {isAnimating ? (
+              <video src={clickAnimation} autoPlay onEnded={handleEnded} />
+            ) : (
+              <video src={defaultVideo} autoPlay loop />
+            )}
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/style.css
+++ b/src/style.css
@@ -1,13 +1,45 @@
-.container {
-  width: 100%;
+/* Overall page layout */
+.layout {
+  display: flex;
+  flex-direction: column;
   height: 100%;
+}
+
+/* Top progress bar */
+.progress-bar {
+  height: 8px;
+  background-color: #eee;
+}
+
+.progress {
+  height: 100%;
+  width: 50%; /* placeholder progress */
+  background-color: #1890ff;
+}
+
+/* Content area containing sidebar and main section */
+.content {
+  flex: 1;
+  display: flex;
+}
+
+/* Sidebar styling */
+.sidebar {
+  width: 200px;
+  background-color: #f5f5f5;
+  padding: 1rem;
+}
+
+/* Main area where the avatar sits */
+.main {
+  flex: 1;
   display: flex;
   justify-content: center;
   align-items: center;
   background-color: #e6f7ff;
 }
 
-video {
+.avatar-container video {
   max-width: 300px;
   border-radius: 8px;
 }


### PR DESCRIPTION
## Summary
- add a simple page layout with top progress bar and sidebar
- center avatar in the new layout
- adjust styling for the new layout
- update HTML page styles

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68572c7c739c8325b22247563358e243