### PR TITLE
Fix intro video and add skip option

### DIFF
--- a/Desktop/AI_HACK/koa-coach/app/(home)/index.js
+++ b/Desktop/AI_HACK/koa-coach/app/(home)/index.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { View, StyleSheet } from "react-native";
+import { View, StyleSheet, TouchableOpacity, Text } from "react-native";
 import Video from "react-native-video";
 import anim1 from "../animations/anime1.mp4";
 import OriginalHome from "./original";
@@ -17,9 +17,20 @@ export default function HomeIndex() {
   }
 
   return (
-    <View style={styles.container}>
-      <Video source={anim1} resizeMode="contain" repeat={false} style={styles.video} />
-    </View>
+    <TouchableOpacity
+      activeOpacity={1}
+      style={styles.container}
+      onPress={() => setShowHome(true)}
+    >
+      <Video
+        source={anim1}
+        resizeMode="contain"
+        repeat={false}
+        paused={false}
+        style={styles.video}
+      />
+      <Text style={styles.skipText}>Tap to skip</Text>
+    </TouchableOpacity>
   );
 }
 
@@ -33,5 +44,11 @@ const styles = StyleSheet.create({
   video: {
     width: "80%",
     height: "80%",
+  },
+  skipText: {
+    position: "absolute",
+    bottom: 30,
+    color: "#fff",
+    fontSize: 16,
   },
 });


### PR DESCRIPTION
## Summary
- add skip button to intro animation so the home screen can be accessed faster

## Testing
- `npx jest --runInBand` *(fails: No tests found)*
- `npm run lint` *(fails: fetch failed due to no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_6857542504208325abccafceb530a71f