### PR TITLE
Fix login flow after splash animation

### DIFF
--- a/Desktop/AI_HACK/koa-coach/app/(home)/index.js
+++ b/Desktop/AI_HACK/koa-coach/app/(home)/index.js
@@ -1,54 +1,146 @@
-import React, { useEffect, useState } from "react";
-import { View, StyleSheet, TouchableOpacity, Text } from "react-native";
-import { Video } from "expo-av";
-import anim1 from "../animations/anime1.mp4";
-import OriginalHome from "./original";
+import { useRouter } from "expo-router";
+import { supabase } from "../../lib/supabase";
+import {
+  View,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  ScrollView,
+  Image,
+} from "react-native";
+import { MaterialIcons, FontAwesome5 } from "@expo/vector-icons";
 
-export default function HomeIndex() {
-  const [showHome, setShowHome] = useState(false);
+export default function HomePage() {
+  const router = useRouter();
 
-  useEffect(() => {
-    const timer = setTimeout(() => setShowHome(true), 5000);
-    return () => clearTimeout(timer);
-  }, []);
-
-  if (showHome) {
-    return <OriginalHome />;
-  }
+  const handleLogout = async () => {
+    try {
+      await supabase.auth.signOut();
+      router.replace("/(auth)");
+    } catch (error) {
+      console.error("Failed to log out:", error);
+    }
+  };
 
   return (
-    <TouchableOpacity
-      activeOpacity={1}
-      style={styles.container}
-      onPress={() => setShowHome(true)}
-    >
-      <Video
-        source={anim1}
-        resizeMode="contain"
-        isLooping={false}
-        shouldPlay
-        style={styles.video}
-      />
-      <Text style={styles.skipText}>Tap to skip</Text>
-    </TouchableOpacity>
+    <ScrollView style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.welcomeText}>Welcome to</Text>
+        <Text style={styles.appName}>KoaCoach</Text>
+        <TouchableOpacity style={styles.logoutButton} onPress={handleLogout}>
+          <MaterialIcons name="logout" size={24} color="#196315" />
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.cardContainer}>
+        <View style={styles.card}>
+          <Image
+            source={require("../../assets/images/icon.png")}
+            style={styles.koalaIcon}
+            resizeMode="contain"
+          />
+
+          <Text style={styles.cardTitle}>Wellness Coach</Text>
+          <Text style={styles.cardDescription}>
+            Koa is your personalized wellness coach, helping you achieve your
+            goals and improve your overall well-being.
+          </Text>
+        </View>
+
+        <View style={styles.card}>
+          <FontAwesome5 name="hand-holding-heart" size={40} color="#196315" />
+          <Text style={styles.cardTitle}>Mindfulness</Text>
+          <Text style={styles.cardDescription}>
+            Koa helps you stay present and focused, reducing stress and anxiety.
+          </Text>
+        </View>
+
+        <TouchableOpacity
+          style={styles.startButton}
+          onPress={() => router.push("/therapist")}
+        >
+          <Text style={styles.startButtonText}>Talk to Koa!</Text>
+        </TouchableOpacity>
+      </View>
+    </ScrollView>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "#000",
-    justifyContent: "center",
-    alignItems: "center",
+    backgroundColor: "#fff",
   },
-  video: {
-    width: "80%",
-    height: "80%",
+  header: {
+    padding: 20,
+    paddingTop: 60,
+    backgroundColor: "#fff",
+    flexDirection: "column",
   },
-  skipText: {
+  welcomeText: {
+    fontSize: 24,
+    color: "#333",
+  },
+  appName: {
+    fontSize: 32,
+    fontWeight: "bold",
+    color: "#196315",
+    marginTop: 5,
+  },
+  logoutButton: {
     position: "absolute",
-    bottom: 30,
-    color: "#fff",
+    top: 60,
+    right: 20,
+    padding: 10,
+  },
+  cardContainer: {
+    padding: 20,
+  },
+  card: {
+    backgroundColor: "#f5f5f5",
+    borderRadius: 15,
+    padding: 20,
+    marginBottom: 20,
+    alignItems: "center",
+    shadowColor: "#000",
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 3,
+  },
+  cardTitle: {
+    fontSize: 20,
+    fontWeight: "bold",
+    color: "#196315",
+    marginTop: 15,
+    marginBottom: 10,
+    textAlign: "center",
+  },
+  cardDescription: {
     fontSize: 16,
+    color: "#666",
+    textAlign: "center",
+    lineHeight: 24,
+  },
+  startButton: {
+    backgroundColor: "#196315",
+    paddingVertical: 15,
+    paddingHorizontal: 30,
+    borderRadius: 25,
+    marginTop: 10,
+  },
+  startButtonText: {
+    color: "#fff",
+    fontSize: 18,
+    fontWeight: "bold",
+    textAlign: "center",
+  },
+  koalaIcon: {
+    width: 80,
+    height: 80,
+    marginBottom: 10,
   },
 });

--- a/Desktop/AI_HACK/koa-coach/app/index.js
+++ b/Desktop/AI_HACK/koa-coach/app/index.js
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from "react";
+import { View, StyleSheet, TouchableOpacity, Text } from "react-native";
+import { Video } from "expo-av";
+import { useRouter } from "expo-router";
+import { supabase } from "../lib/supabase";
+import anim1 from "./animations/anime1.mp4";
+
+export default function SplashScreen() {
+  const router = useRouter();
+  const [redirecting, setRedirecting] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(handleEnd, 5000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  const handleEnd = async () => {
+    if (redirecting) return;
+    setRedirecting(true);
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+    if (session) {
+      router.replace("/(home)");
+    } else {
+      router.replace("/(auth)");
+    }
+  };
+
+  if (redirecting) {
+    return <View style={styles.container} />;
+  }
+
+  return (
+    <TouchableOpacity
+      activeOpacity={1}
+      style={styles.container}
+      onPress={handleEnd}
+    >
+      <Video
+        source={anim1}
+        resizeMode="contain"
+        isLooping={false}
+        shouldPlay
+        style={styles.video}
+      />
+      <Text style={styles.skipText}>Tap to skip</Text>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#000",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  video: {
+    width: "80%",
+    height: "80%",
+  },
+  skipText: {
+    position: "absolute",
+    bottom: 30,
+    color: "#fff",
+    fontSize: 16,
+  },
+});


### PR DESCRIPTION
## Summary
- add a splash screen with video that routes to auth or home
- replace home index with actual home page content

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685763e7bc1883258da072407428e3a0