### PR TITLE
Fix animation flow and add login streak

### DIFF
--- a/Desktop/AI_HACK/koa-coach/app/(home)/index.js
+++ b/Desktop/AI_HACK/koa-coach/app/(home)/index.js
@@ -1,5 +1,7 @@
+import React from "react";
 import { useRouter } from "expo-router";
 import { supabase } from "../../lib/supabase";
+import { updateStreak } from "../../lib/streak";
 import {
   View,
   StyleSheet,
@@ -12,6 +14,15 @@ import { MaterialIcons, FontAwesome5 } from "@expo/vector-icons";
 
 export default function HomePage() {
   const router = useRouter();
+  const [streak, setStreak] = React.useState(0);
+
+  React.useEffect(() => {
+    const load = async () => {
+      const value = await updateStreak();
+      setStreak(value);
+    };
+    load();
+  }, []);
 
   const handleLogout = async () => {
     try {
@@ -30,6 +41,9 @@ export default function HomePage() {
         <TouchableOpacity style={styles.logoutButton} onPress={handleLogout}>
           <MaterialIcons name="logout" size={24} color="#196315" />
         </TouchableOpacity>
+        <View style={styles.streakBar}>
+          <Text style={styles.streakText}>{streak}</Text>
+        </View>
       </View>
 
       <View style={styles.cardContainer}>
@@ -92,6 +106,19 @@ const styles = StyleSheet.create({
     top: 60,
     right: 20,
     padding: 10,
+  },
+  streakBar: {
+    position: "absolute",
+    top: 60,
+    right: 80,
+    backgroundColor: "#FFD700",
+    paddingVertical: 4,
+    paddingHorizontal: 8,
+    borderRadius: 10,
+  },
+  streakText: {
+    fontWeight: "bold",
+    color: "#000",
   },
   cardContainer: {
     padding: 20,

--- a/Desktop/AI_HACK/koa-coach/app/(home)/therapist.js
+++ b/Desktop/AI_HACK/koa-coach/app/(home)/therapist.js
@@ -19,7 +19,10 @@ import Anthropic from "@anthropic-ai/sdk";
 import { Audio } from "expo-av";
 import * as FileSystem from "expo-file-system";
 import { FontAwesome, MaterialIcons } from "@expo/vector-icons";
-import { loadAnimations } from "../actions/animations";
+import {
+  loadAnimeAnimations,
+  loadActionAnimations,
+} from "../actions/animations";
 import avatarImage from "../anime/koa.png";
 
 const flagIcons = {
@@ -87,14 +90,12 @@ const TherapistChat = () => {
 
   
 
-  const ensureAnimations = () => {
-    if (!animationsRef.current) {
-      animationsRef.current = loadAnimations();
-    }
+  const loadAnimationsByType = (type) => {
+    animationsRef.current =
+      type === "action" ? loadActionAnimations() : loadAnimeAnimations();
   };
 
   const playNextAnimation = () => {
-    ensureAnimations();
     const animList = animationsRef.current;
     const next = animList[videoIndex.current % animList.length];
     videoIndex.current = (videoIndex.current + 1) % animList.length;
@@ -108,6 +109,9 @@ const TherapistChat = () => {
       setLooping(false);
       setCurrentVideo(null);
     } else {
+      setLooping(false);
+      videoIndex.current = 0;
+      loadAnimationsByType("action");
       playNextAnimation();
     }
   };
@@ -123,6 +127,8 @@ const TherapistChat = () => {
 
   const handleLoopAll = () => {
     setLooping(true);
+    videoIndex.current = 0;
+    loadAnimationsByType("anime");
     playNextAnimation();
   };
 

--- a/Desktop/AI_HACK/koa-coach/app/actions/animations.js
+++ b/Desktop/AI_HACK/koa-coach/app/actions/animations.js
@@ -1,10 +1,23 @@
-export function loadAnimations() {
+export function loadAnimeAnimations() {
   return [
-    require('../anime/anime1.mp4'),
-    require('../anime/anime2.mp4'),
-    require('../anime/anime3.mp4'),
-    require('../anime/anime4.mp4'),
-    require('../anime/anime5.mp4'),
-    require('../anime/anime6.mp4'),
+    require("../anime/anime1.mp4"),
+    require("../anime/anime2.mp4"),
+    require("../anime/anime3.mp4"),
+    require("../anime/anime4.mp4"),
+    require("../anime/anime5.mp4"),
+    require("../anime/anime6.mp4"),
   ];
 }
+
+export function loadActionAnimations() {
+  return [
+    require("../animations/action1.mp4"),
+    require("../animations/action2.mp4"),
+    require("../animations/action3.mp4"),
+    require("../animations/action4.mp4"),
+    require("../animations/action5.mp4"),
+  ];
+}
+
+// Backwards compatibility with older imports
+export const loadAnimations = loadAnimeAnimations;

--- a/Desktop/AI_HACK/koa-coach/app/index.js
+++ b/Desktop/AI_HACK/koa-coach/app/index.js
@@ -3,12 +3,12 @@ import { View, StyleSheet, TouchableOpacity, Text } from "react-native";
 import { Video } from "expo-av";
 import { useRouter } from "expo-router";
 import { supabase } from "../lib/supabase";
-import { loadAnimations } from "./actions/animations";
+import { loadAnimeAnimations } from "./actions/animations";
 
 export default function SplashScreen() {
   const router = useRouter();
   const [redirecting, setRedirecting] = useState(false);
-  const [anim1] = loadAnimations();
+  const [anim1] = loadAnimeAnimations();
 
   useEffect(() => {
     const timer = setTimeout(handleEnd, 5000);

--- a/Desktop/AI_HACK/koa-coach/lib/streak.js
+++ b/Desktop/AI_HACK/koa-coach/lib/streak.js
@@ -1,0 +1,52 @@
+import { supabase } from "./supabase";
+
+export async function updateStreak() {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return 0;
+
+  const today = new Date().toISOString().slice(0, 10);
+  let { data, error } = await supabase
+    .from("streaks")
+    .select("streak,last_login")
+    .eq("user_id", user.id)
+    .single();
+  if (error && !error.message?.includes("No rows")) {
+    console.error("Fetch streak error", error);
+    return 0;
+  }
+
+  let newStreak = 1;
+  if (data) {
+    const last = data.last_login?.slice(0, 10);
+    if (last === today) {
+      newStreak = data.streak || 1;
+    } else if (last && Math.floor((new Date(today) - new Date(last)) / 86400000) === 1) {
+      newStreak = (data.streak || 0) + 1;
+    }
+
+    await supabase
+      .from("streaks")
+      .update({ streak: newStreak, last_login: today })
+      .eq("user_id", user.id);
+  } else {
+    await supabase
+      .from("streaks")
+      .insert({ user_id: user.id, streak: newStreak, last_login: today });
+  }
+  return newStreak;
+}
+
+export async function fetchStreak() {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return 0;
+  const { data } = await supabase
+    .from("streaks")
+    .select("streak")
+    .eq("user_id", user.id)
+    .single();
+  return data?.streak || 0;
+}


### PR DESCRIPTION
## Summary
- separate anime and action animation loaders
- make therapist avatar click play action animations
- loop 'anime' animations when Loop button used
- show login streak on home screen and track it in Supabase

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68579098b8cc83258463c54a2271e53b