### PR TITLE
Add Koala demo with web browsing and email agent

### DIFF
--- a/unify-hackathon-demo/README.md
+++ b/unify-hackathon-demo/README.md
@@ -1,0 +1,10 @@
+# Koala Web Browser & Email Agent
+
+This demo showcases a cute koala agent that:
+
+1. Opens a web page with interesting information.
+2. Sends an email to Haoming describing what it found.
+3. Optionally records its activity using `ffmpeg` if available.
+
+Edit SMTP environment variables to enable email sending:
+`SMTP_HOST`, `SMTP_USER`, `SMTP_PASS`, `SMTP_TO`, and `SMTP_PORT`.

--- a/unify-hackathon-demo/demo.py
+++ b/unify-hackathon-demo/demo.py
@@ -1,0 +1,62 @@
+import os
+import webbrowser
+import smtplib
+from email.mime.text import MIMEText
+import subprocess
+
+KOALA_PROMPT = (
+    "You are a cute koala bear named Koala. "
+    "Your task is to search something interesting on the web "
+    "and send an email to your friend Haoming about these in a cute tone. "
+    "Include what you found as URLs."
+)
+
+def start_recording(filename="activity.mp4"):
+    cmd = [
+        "ffmpeg", "-y", "-video_size", "1920x1080", "-f", "x11grab",
+        "-i", os.environ.get("DISPLAY", ":0"), filename
+    ]
+    try:
+        return subprocess.Popen(cmd)
+    except FileNotFoundError:
+        print("ffmpeg not found, skipping recording.")
+        return None
+
+def stop_recording(proc):
+    if proc:
+        proc.terminate()
+        proc.wait()
+
+def search_and_browse(url):
+    print(f"Koala is browsing: {url}")
+    webbrowser.open(url)
+
+def send_email(message, url):
+    host = os.environ.get("SMTP_HOST")
+    user = os.environ.get("SMTP_USER")
+    password = os.environ.get("SMTP_PASS")
+    to = os.environ.get("SMTP_TO", "haoming@example.com")
+    port = int(os.environ.get("SMTP_PORT", 587))
+
+    if not (host and user and password):
+        print("Missing SMTP configuration, skipping email.")
+        return
+
+    body = f"Hi Haoming! Koala found something interesting: {url}\n{message}"
+    msg = MIMEText(body)
+    msg["Subject"] = "Koala's cute findings"
+    msg["From"] = user
+    msg["To"] = to
+
+    with smtplib.SMTP(host, port) as server:
+        server.starttls()
+        server.login(user, password)
+        server.send_message(msg)
+
+if __name__ == "__main__":
+    print(KOALA_PROMPT)
+    recorder = start_recording()
+    url = "https://en.wikipedia.org/wiki/Koala"
+    search_and_browse(url)
+    send_email("Check out this link!", url)
+    stop_recording(recorder)


### PR DESCRIPTION
## Summary
- replace empty `unify-hackathon-demo` submodule with actual demo files
- implement `demo.py` showing a cute Koala searching the web, sending an email, and optionally recording the session
- add README with setup details

## Testing
- `python3 unify-hackathon-demo/demo.py`

------
https://chatgpt.com/codex/tasks/task_e_6857b7a2dc908325873d642afcb54122