### PR TITLE
Update README and constants

### DIFF
--- a/unify-hackathon-demo/README.md
+++ b/unify-hackathon-demo/README.md
@@ -1,11 +1,37 @@
-# Koala Web Browser & Email Agent
+# Unify Hackathon Demo
 
-This demo showcases a cute koala agent that:
+This project contains a small demo of the **planning agent** approach used in [Unify](https://github.com/unifyai). The agent can open a browser, search the web and create an email draft based on your resume.
 
-1. Opens a web page with interesting information.
-2. Sends an email to Haoming describing what it found.
-3. Optionally records its activity using `ffmpeg` if available.
-4. Loads `koala_info.txt` for Koala's name and hobbies.
+## Setup
 
-Edit SMTP environment variables to enable email sending:
-`SMTP_HOST`, `SMTP_USER`, `SMTP_PASS`, `SMTP_TO`, and `SMTP_PORT`.
+1. Install the dependencies using [uv](https://github.com/astral-sh/uv):
+
+   ```bash
+   uv sync
+   ```
+
+2. Playwright requires a one‑time download of its browser binaries. Run:
+
+   ```bash
+   uv run playwright install
+   ```
+
+   Without this step you'll see an error like `BrowserType.launch: Executable doesn't exist`.
+
+3. (Optional) To run your existing Chrome profile with remote debugging enabled execute:
+
+   ```bash
+   ./start_chrome_debug.sh
+   ```
+
+   The agent will try to connect to Chrome on port `9222` and fall back to Playwright's Chromium if it cannot.
+
+4. Adjust values in `specialized_agents/constants.py` such as `RESUME_PATH` and `JOB_PAGE_URL` so the agent uses your resume and the job posting you want.
+
+5. Run the planning agent:
+
+   ```bash
+   uv run -m specialized_agents.planning_agent
+   ```
+
+The agent will orchestrate a research tool and a computer tool to browse the web and draft an email. Set the SMTP environment variables (`SMTP_HOST`, `SMTP_USER`, `SMTP_PASS`, `SMTP_TO`, `SMTP_PORT`) if you want the demo email functionality.

--- a/unify-hackathon-demo/specialized_agents/constants.py
+++ b/unify-hackathon-demo/specialized_agents/constants.py
@@ -5,8 +5,8 @@ COMPUTER_MODEL = "computer-use-preview"
 PLANNER_MAX_TURNS = 200
 TOOL_MAX_TURNS = 50
 
-# Adjust this to your resume path (.txt or .pdf)
-RESUME_PATH = "Users/haoming/Downloads/Haoming_Chen_Resume_So.docx.txt"
+# Path to your resume (.txt or .pdf). Defaults to the sample resume in this repo.
+RESUME_PATH = "resume.pdf"
 
 # Adjust this to the job posting you want to apply for
 JOB_PAGE_URL = "https://jobs.ashbyhq.com/unify/95113ca1-4f4a-4435-8636-5758ce0d155e"


### PR DESCRIPTION
## Summary
- document how to set up and run the planning agent demo
- default resume path to the sample resume

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857c09b0a0883259df40701a4f9aaed