### PR TITLE
Add video agent trigger

### DIFF
--- a/Desktop/AI_HACK/koa-coach/app/(home)/match.js
+++ b/Desktop/AI_HACK/koa-coach/app/(home)/match.js
@@ -27,6 +27,14 @@ const MatchScreen = () => {
     setShowRosyCard(true);
   };
 
+  const triggerAgent = async () => {
+    try {
+      await fetch('http://localhost:3001/run-agent', { method: 'POST' });
+    } catch (e) {
+      console.error('Failed to start agent', e);
+    }
+  };
+
   const handleSend = () => {
     if (inputText.trim()) {
       const userMsg = { role: "user", content: inputText.trim() };
@@ -56,6 +64,10 @@ const MatchScreen = () => {
       </View>
       <TouchableOpacity style={styles.matchButton} onPress={handleMatch}>
         <Text style={styles.matchButtonText}>Match Me</Text>
+      </TouchableOpacity>
+
+      <TouchableOpacity style={styles.agentButton} onPress={triggerAgent}>
+        <Text style={styles.agentButtonText}>Run Agent Demo</Text>
       </TouchableOpacity>
 
       {showRosyCard && (
@@ -231,6 +243,18 @@ const styles = StyleSheet.create({
     height: 40,
     justifyContent: "center",
     alignItems: "center",
+  },
+  agentButton: {
+    backgroundColor: "#FF5722",
+    borderRadius: 10,
+    padding: 20,
+    marginVertical: 16,
+    alignItems: "center",
+  },
+  agentButtonText: {
+    color: "#fff",
+    fontSize: 20,
+    fontWeight: "bold",
   },
   noticeBox: {
     backgroundColor: "#FFF3CD",

--- a/Desktop/AI_HACK/koa-coach/backend/agentServer.js
+++ b/Desktop/AI_HACK/koa-coach/backend/agentServer.js
@@ -1,0 +1,24 @@
+const http = require('http');
+const { spawn } = require('child_process');
+const path = require('path');
+
+const scriptPath = path.join(__dirname, '..', '..', '..', 'unify-hackathon-demo', 'video_agent', '__main__.py');
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'POST' && req.url === '/run-agent') {
+    const proc = spawn('python3', [scriptPath]);
+    proc.stdout.on('data', d => console.log(d.toString()));
+    proc.stderr.on('data', d => console.error(d.toString()));
+    proc.on('close', c => console.log('agent exited', c));
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ status: 'started' }));
+  } else {
+    res.statusCode = 404;
+    res.end('Not found');
+  }
+});
+
+const PORT = process.env.PORT || 3001;
+server.listen(PORT, () => {
+  console.log(`Agent server listening on ${PORT}`);
+});

--- a/Desktop/AI_HACK/koa-coach/package.json
+++ b/Desktop/AI_HACK/koa-coach/package.json
@@ -9,7 +9,8 @@
     "ios": "expo start --ios",
     "web": "expo start --web",
     "test": "jest --watchAll",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "agent-server": "node backend/agentServer.js"
   },
   "jest": {
     "preset": "jest-expo"

--- a/unify-hackathon-demo/video_agent/__init__.py
+++ b/unify-hackathon-demo/video_agent/__init__.py
@@ -1,0 +1,83 @@
+import os
+import webbrowser
+import smtplib
+from email.mime.text import MIMEText
+import subprocess
+
+INFO_FILE = os.path.join(os.path.dirname(__file__), "..", "koala_info.txt")
+
+KOALA_PROMPT = (
+    "You are a cute cute koala bear referring to yourself as Koala. "
+    "Your task is to search something cute interesting on the website and send an "
+    "email to your friend Haoming about these in a cute tone. Include what "
+    "you found as URLs. Load the text file at "
+    f"{INFO_FILE} for yourto refer to the user - be very personal - for instace, Hi dear Haoming, Koala is board today to not see you, but Koala found some cute animal videos online!."
+)
+
+def load_info(path=INFO_FILE):
+    try:
+        with open(path, "r") as f:
+            return f.read().strip()
+    except FileNotFoundError:
+        return ""
+
+def start_recording(filename="activity.mp4"):
+    cmd = [
+        "ffmpeg", "-y", "-video_size", "1920x1080", "-f", "x11grab",
+        "-i", os.environ.get("DISPLAY", ":0"), filename
+    ]
+    try:
+        return subprocess.Popen(cmd)
+    except FileNotFoundError:
+        print("ffmpeg not found, skipping recording.")
+        return None
+
+def stop_recording(proc):
+    if proc:
+        proc.terminate()
+        proc.wait()
+
+def search_and_browse(url):
+    print(f"Koala is browsing: {url}")
+    webbrowser.open(url)
+
+def send_email(message, url):
+    host = os.environ.get("SMTP_HOST")
+    user = os.environ.get("SMTP_USER")
+    password = os.environ.get("SMTP_PASS")
+    to = os.environ.get("SMTP_TO", "haoming@example.com")
+    port = int(os.environ.get("SMTP_PORT", 587))
+
+    if not (host and user and password):
+        print("Missing SMTP configuration, skipping email.")
+        return
+
+    body = f"Hi Haoming! Koala found something interesting: {url}\n{message}"
+    msg = MIMEText(body)
+    msg["Subject"] = "Koala's cute findings"
+    msg["From"] = user
+    msg["To"] = to
+
+    with smtplib.SMTP(host, port) as server:
+        server.starttls()
+        server.login(user, password)
+        server.send_message(msg)
+
+def run() -> None:
+    """Run the koala video agent."""
+    print(KOALA_PROMPT)
+    info = load_info()
+    recorder = start_recording()
+    url = "https://en.wikipedia.org/wiki/Koala"
+    search_and_browse(url)
+    message = f"{info}\nCheck out this link!"
+    send_email(message, url)
+    stop_recording(recorder)
+
+
+def main() -> None:
+    run()
+
+
+if __name__ == "__main__":
+    main()

--- a/unify-hackathon-demo/video_agent/__main__.py
+++ b/unify-hackathon-demo/video_agent/__main__.py
@@ -1,0 +1,4 @@
+from . import main
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- package koala video agent as module
- add lightweight HTTP server to run the agent
- expose server via npm script
- add large button on match screen to trigger the agent

## Testing
- `npm test --silent`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6857ccb68afc832591e6029e51ce5ca7